### PR TITLE
ValueInterface requires getValue()

### DIFF
--- a/src/ValueObjects/AbstractValue.php
+++ b/src/ValueObjects/AbstractValue.php
@@ -49,6 +49,11 @@ abstract class AbstractValue implements ValueInterface
         return $this;
     }
 
+    public function getValue(): mixed
+    {
+        return $this->value;
+    }
+
     public function reformatValue(): self
     {
         $this->formatted = $this->setFormattedValue($this->value);

--- a/src/ValueObjects/ValueInterface.php
+++ b/src/ValueObjects/ValueInterface.php
@@ -4,4 +4,5 @@ namespace SecureSpace\ValueObjects;
 
 interface ValueInterface
 {
+    public function getValue(): mixed;
 }

--- a/tests/Unit/ValueObjects/AbstractValueTest.php
+++ b/tests/Unit/ValueObjects/AbstractValueTest.php
@@ -7,6 +7,15 @@ use SecureSpace\ValueObjects\NumberValue;
 
 class AbstractValueTest extends TestCase
 {
+    public function testGetValue(): void
+    {
+        $number = NumberValue::from(617);
+        $this->assertEquals(617, $number->getValue());
+
+        $number->setValue(821);
+        $this->assertEquals(821, $number->getValue());
+    }
+
     public function testSetValue(): void
     {
         $number = NumberValue::from(721);


### PR DESCRIPTION
Betters IDE hinting when using `ValueInterface` as a type hint in method signatures.