### PR TITLE
Percent From Fraction

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
   "minimum-stability": "stable",
   "prefer-stable": true,
   "scripts": {
+    "coverage": [
+      "@php -dxdebug.mode=coverage ./vendor/bin/phpunit --coverage-html tests/Coverage/"
+    ],
     "test": [
       "@php phpunit"
     ]

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
 >
+    <!-- Generate coverage via $ composer coverage -->
     <coverage processUncoveredFiles="true">
         <include>
             <directory suffix=".php">./src</directory>
@@ -12,6 +13,8 @@
     </coverage>
 
     <testsuites>
-        <testsuite name="Unit" />
+        <testsuite name="Unit">
+            <directory>tests</directory>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Values/AbstractValue.php
+++ b/src/Values/AbstractValue.php
@@ -2,6 +2,7 @@
 
 namespace SecureSpace\ValueObjects\Values;
 
+use Closure;
 use SecureSpace\ValueObjects\Exceptions\UnsupportedValueType;
 
 abstract class AbstractValue implements ValueInterface
@@ -9,7 +10,7 @@ abstract class AbstractValue implements ValueInterface
     /** Human-readable readable string representing the value of the value.  */
     public string $formatted;
 
-    public \Closure | null $formatter;
+    public Closure | null $formatter;
 
     public mixed $value;
 
@@ -35,11 +36,11 @@ abstract class AbstractValue implements ValueInterface
     public static function from($value): static | NullValue
     {
         return is_null($value)
-            ? new NullValue(null)
+            ? new NullValue()
             : new static($value);
     }
 
-    public function format(\callable | \Closure | null $formatter = null): string
+    public function format(callable | Closure | null $formatter = null): string
     {
         $this->formatter = $formatter;
 
@@ -48,7 +49,7 @@ abstract class AbstractValue implements ValueInterface
             : $this->toString();
     }
 
-    public function formatWith(\callable | \Closure $formatter): self
+    public function formatWith(callable | Closure $formatter): self
     {
         $this->formatter = $formatter;
         $this->formatted = $formatter($this);

--- a/src/Values/NullValue.php
+++ b/src/Values/NullValue.php
@@ -4,6 +4,11 @@ namespace SecureSpace\ValueObjects\Values;
 
 class NullValue extends AbstractValue
 {
+    public function __construct()
+    {
+        parent::__construct(null);
+    }
+
     public static function cast($value): mixed
     {
         return null;

--- a/src/Values/PercentValue.php
+++ b/src/Values/PercentValue.php
@@ -5,13 +5,13 @@ namespace SecureSpace\ValueObjects\Values;
 class PercentValue extends FloatValue
 {
     public static function fromFraction(
-        int | IntegerValue $numerator,
-        int | IntegerValue $denominator,
+        float | int | FloatValue | IntegerValue $numerator,
+        float | int | FloatValue | IntegerValue $denominator,
     ): self | NullValue
     {
         return 0 === $denominator
             ? new NullValue(null)
-            : new self($numerator / $denominator);
+            : new self((float) $numerator / $denominator);
     }
 
     public function toString(): string

--- a/tests/Values/AbstractValueTest.php
+++ b/tests/Values/AbstractValueTest.php
@@ -3,6 +3,7 @@
 namespace SecureSpace\ValueObjects\Tests\Values;
 
 use PHPUnit\Framework\TestCase;
+use SecureSpace\ValueObjects\Exceptions\UnsupportedValueType;
 use SecureSpace\ValueObjects\Values\IntegerValue;
 
 class AbstractValueTest extends TestCase
@@ -25,6 +26,9 @@ class AbstractValueTest extends TestCase
         $number->setValue(1021);
         $this->assertEquals(1021, $number->value);
         $this->assertEquals('1,021', $number->formatted);
+
+        $this->expectException(UnsupportedValueType::class);
+        $number->setValue('foo bar');
     }
 
     public function testToArray(): void

--- a/tests/Values/BooleanValueTest.php
+++ b/tests/Values/BooleanValueTest.php
@@ -8,6 +8,15 @@ use SecureSpace\ValueObjects\Values\NullValue;
 
 class BooleanValueTest extends TestCase
 {
+    public function testCast(): void
+    {
+        $this->assertTrue(BooleanValue::cast(1));
+        $this->assertTrue(BooleanValue::cast(true));
+        $this->assertFalse(BooleanValue::cast(0));
+        $this->assertFalse(BooleanValue::cast(false));
+        $this->assertFalse(BooleanValue::cast(null));
+    }
+
     public function testFrom(): void
     {
         $bool = BooleanValue::from(null);

--- a/tests/Values/FloatValueTest.php
+++ b/tests/Values/FloatValueTest.php
@@ -8,6 +8,13 @@ use SecureSpace\ValueObjects\Values\NullValue;
 
 class FloatValueTest extends TestCase
 {
+    public function testCast(): void
+    {
+        $this->assertEquals(1.0, FloatValue::cast(1));
+        $this->assertEquals(1.0, FloatValue::cast(1.0));
+        $this->assertEquals(null, FloatValue::cast(null));
+    }
+
     public function testFrom(): void
     {
         $float = FloatValue::from(null);

--- a/tests/Values/InfinityValueTest.php
+++ b/tests/Values/InfinityValueTest.php
@@ -7,6 +7,16 @@ use SecureSpace\ValueObjects\Values\InfinityValue;
 
 class InfinityValueTest extends TestCase
 {
+    public function testCast(): void
+    {
+        $this->assertEquals(INF, InfinityValue::cast(INF));
+        $this->assertEquals(INF, InfinityValue::cast(0));
+        $this->assertEquals(INF, InfinityValue::cast(1.23));
+        $this->assertEquals(INF, InfinityValue::cast(true));
+        $this->assertEquals(INF, InfinityValue::cast(null));
+        $this->assertEquals(INF, InfinityValue::cast(['foo' => 'bar']));
+    }
+
     /** Infinity, regardless of what's given, can only ever be infinity. */
     public function testFrom(): void
     {

--- a/tests/Values/IntegerValueTest.php
+++ b/tests/Values/IntegerValueTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SecureSpace\ValueObjects\Tests\Values;
+
+use PHPUnit\Framework\TestCase;
+use SecureSpace\ValueObjects\Values\IntegerValue;
+
+class IntegerValueTest extends TestCase
+{
+    public function testCast(): void
+    {
+        $this->assertEquals(1, IntegerValue::cast(1));
+        $this->assertEquals(1, IntegerValue::cast(1.0));
+        $this->assertEquals(null, IntegerValue::cast(null));
+        $this->assertEquals(null, IntegerValue::cast('foo'));
+    }
+}

--- a/tests/Values/NullValueTest.php
+++ b/tests/Values/NullValueTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SecureSpace\ValueObjects\Tests\Values;
+
+use PHPUnit\Framework\TestCase;
+use SecureSpace\ValueObjects\Values\IntegerValue;
+use SecureSpace\ValueObjects\Values\NullValue;
+
+class NullValueTest extends TestCase
+{
+    public function testCast(): void
+    {
+        $this->assertNull(NullValue::cast(null));
+        $this->assertNull(NullValue::cast(true));
+        $this->assertNull(NullValue::cast(false));
+        $this->assertNull(NullValue::cast(123));
+        $this->assertNull(NullValue::cast(123.45));
+        $this->assertNull(NullValue::cast(INF));
+        $this->assertNull(NullValue::cast(['foo' => 'bar']));
+        $this->assertNull(NullValue::cast(IntegerValue::from(123)));
+    }
+
+    public function testFrom(): void
+    {
+        $this->assertEquals(new NullValue(), NullValue::from(null));
+        $this->assertEquals(new NullValue(), NullValue::from(true));
+        $this->assertEquals(new NullValue(), NullValue::from(false));
+        $this->assertEquals(new NullValue(), NullValue::from(123));
+        $this->assertEquals(new NullValue(), NullValue::from(123.45));
+        $this->assertEquals(new NullValue(), NullValue::from(INF));
+        $this->assertEquals(new NullValue(), NullValue::from(['foo' => 'bar']));
+        $this->assertEquals(new NullValue(), NullValue::from(IntegerValue::from(123)));
+    }
+
+    public function testToString(): void
+    {
+        $this->assertEquals('null', (string) NullValue::from(null));
+        $this->assertEquals('null', (string) NullValue::from(true));
+        $this->assertEquals('null', (string) NullValue::from(false));
+        $this->assertEquals('null', (string) NullValue::from(123));
+        $this->assertEquals('null', (string) NullValue::from(123.45));
+        $this->assertEquals('null', (string) NullValue::from(INF));
+        $this->assertEquals('null', (string) NullValue::from(['foo' => 'bar']));
+        $this->assertEquals('null', (string) NullValue::from(IntegerValue::from(123)));
+    }
+}

--- a/tests/Values/PercentValueTest.php
+++ b/tests/Values/PercentValueTest.php
@@ -51,6 +51,10 @@ class PercentValueTest extends TestCase
         $this->assertEquals('33.33%', $percent->formatted);
         $this->assertEquals(0.3333333333333333, $percent->value);
 
+        $percent = PercentValue::fromFraction(10, 5);
+        $this->assertEquals('200.00%', $percent->formatted);
+        $this->assertEquals(2.0, $percent->value);
+
         $percent = PercentValue::fromFraction(10, 21)->setPrecision(5);
         $this->assertEquals('47.61905%', $percent->formatted);
         $this->assertEquals(5, $percent->precision);

--- a/tests/Values/StringValueTest.php
+++ b/tests/Values/StringValueTest.php
@@ -8,6 +8,17 @@ use SecureSpace\ValueObjects\Values\StringValue;
 
 class StringValueTest extends TestCase
 {
+    public function testCast(): void
+    {
+        $this->assertEquals('foo', StringValue::cast('foo'));
+        $this->assertEquals('FOO', StringValue::cast('FOO'));
+        $this->assertEquals('123', StringValue::cast(123));
+        $this->assertEquals('123', StringValue::cast(123.00));
+        $this->assertEquals('', StringValue::cast(null));
+        $this->assertEquals('1', StringValue::cast(true));
+        $this->assertEquals('', StringValue::cast(false));
+    }
+
     public function testFrom(): void
     {
         $string = StringValue::from(null);


### PR DESCRIPTION
Earlier, when creating a `PercentValue` from a fraction (ie: `PercentValue::fromFraction()` if the calculation resulted in an integer, the percent value object could not be created as a float is required. Now, we cast the value passed to the parent to a float to ensure the object can be created.