### PR TITLE
Float Supports Int

### DIFF
--- a/src/Values/FloatValue.php
+++ b/src/Values/FloatValue.php
@@ -25,7 +25,7 @@ class FloatValue extends AbstractValue
 
     public function supports($value): bool
     {
-        return is_float($value);
+        return is_float($value) || is_int($value);
     }
 
     public function toString(): string

--- a/tests/Values/FloatValueTest.php
+++ b/tests/Values/FloatValueTest.php
@@ -36,6 +36,10 @@ class FloatValueTest extends TestCase
         $this->assertEquals('-98.76', $float->formatted);
         $this->assertEquals(-98.76, $float->value);
 
+        $float = FloatValue::from(123);
+        $this->assertEquals('123.00', $float->formatted);
+        $this->assertEquals(123.00, $float->value);
+
         $this->assertEquals(
             expected: 'Pi: 3.14159',
             actual: FloatValue::from(3.14159)


### PR DESCRIPTION
A `FloatValue` will support an `int` and automatically cast the raw value to a float. This helps when creating a `FloatValue` from a dynamic value where said value may be an `int`.