### PR TITLE
Float Supports Whole

### DIFF
--- a/src/Values/PercentValue.php
+++ b/src/Values/PercentValue.php
@@ -10,8 +10,13 @@ class PercentValue extends FloatValue
     ): self | NullValue
     {
         return 0 === $denominator
-            ? new NullValue(null)
+            ? new NullValue()
             : new self((float) $numerator / $denominator);
+    }
+
+    public static function fromWhole(float | int | FloatValue | IntegerValue $value): self | NullValue
+    {
+        return new self($value / 100);
     }
 
     public function toString(): string

--- a/tests/Values/PercentValueTest.php
+++ b/tests/Values/PercentValueTest.php
@@ -64,4 +64,38 @@ class PercentValueTest extends TestCase
         $this->assertEquals('', $percent->formatted);
         $this->assertNull($percent->value);
     }
+
+    public function testFromWhole(): void
+    {
+        $percent = PercentValue::fromWhole(0);
+        $this->assertEquals('0.00%', $percent->formatted);
+        $this->assertEquals(0.0, $percent->value);
+
+        $percent = PercentValue::fromWhole(100);
+        $this->assertEquals('100.00%', $percent->formatted);
+        $this->assertEquals(1.0, $percent->value);
+
+        $percent = PercentValue::fromWhole(12.3456);
+        $this->assertEquals('12.35%', $percent->formatted);
+        $this->assertEquals(0.123456, $percent->value);
+
+        $percent = PercentValue::fromWhole(-98.76);
+        $this->assertEquals('-98.76%', $percent->formatted);
+        $this->assertEquals(-0.9876, $percent->value);
+
+        $this->assertEquals(
+            expected: 'Increase: 110%',
+            actual: PercentValue::fromWhole(110)
+                ->setPrecision(0)
+                ->format(fn(PercentValue $p) => "Increase: $p")
+        );
+
+        $percent = PercentValue::fromWhole(10)
+            ->setPrecision(0)
+            ->formatWith(fn(PercentValue $p) => "$p Off")
+            ->toArray()
+        ;
+
+        $this->assertEquals('10% Off', $percent['formatted']);
+    }
 }


### PR DESCRIPTION
A `FloatValue` will support an `int` and automatically cast the raw value to a float. This helps when creating a `FloatValue` from a dynamic value where said value may be an `int`.

Added `PercentValue::fromWhole()` to create a `PercentValue` from a whole number. This makes it easier to work with `PercentValue` when the data source provides percents as numbers between zero and 100.