### PR TITLE
Float to Array

### DIFF
--- a/src/Values/FloatValue.php
+++ b/src/Values/FloatValue.php
@@ -28,6 +28,13 @@ class FloatValue extends AbstractValue
         return is_float($value) || is_int($value);
     }
 
+    public function toArray(): array
+    {
+        return array_merge(parent::toArray(), [
+            'precision' => $this->precision,
+        ]);
+    }
+
     public function toString(): string
     {
         return number_format($this->value, $this->precision);

--- a/src/Values/NullValue.php
+++ b/src/Values/NullValue.php
@@ -14,7 +14,7 @@ class NullValue extends AbstractValue
         return null;
     }
 
-    public static function from($value): static
+    public static function from($value = null): static
     {
         return new self(null);
     }

--- a/tests/Values/FloatValueTest.php
+++ b/tests/Values/FloatValueTest.php
@@ -69,4 +69,15 @@ class FloatValueTest extends TestCase
         $this->assertEquals('0.12345679', $float->setPrecision(8)->formatted);
         $this->assertEquals('0.123456789', $float->setPrecision(9)->formatted);
     }
+
+    public function testToArray(): void
+    {
+        $expected = [
+            'formatted' => '0.123',
+            'precision' => 3,
+            'value' => 0.123456,
+        ];
+
+        $this->assertEquals($expected, FloatValue::from(0.123456)->setPrecision(3)->toArray());
+    }
 }


### PR DESCRIPTION
When converting a `FloatValue` to an array, include the precision value as well.