### PR TITLE
Percent Denominators

### DIFF
--- a/src/Values/PercentValue.php
+++ b/src/Values/PercentValue.php
@@ -9,7 +9,7 @@ class PercentValue extends FloatValue
         float | int | FloatValue | IntegerValue $denominator,
     ): self | NullValue
     {
-        return 0 === $denominator
+        return 0.0 === (float) $denominator
             ? new NullValue()
             : new self((float) $numerator / $denominator);
     }

--- a/tests/Values/PercentValueTest.php
+++ b/tests/Values/PercentValueTest.php
@@ -3,6 +3,7 @@
 namespace SecureSpace\ValueObjects\Tests\Values;
 
 use PHPUnit\Framework\TestCase;
+use SecureSpace\ValueObjects\Values\NullValue;
 use SecureSpace\ValueObjects\Values\PercentValue;
 
 class PercentValueTest extends TestCase
@@ -39,8 +40,7 @@ class PercentValueTest extends TestCase
         $percent = PercentValue::from(0.10)
             ->setPrecision(0)
             ->formatWith(fn(PercentValue $p) => "$p Off")
-            ->toArray()
-        ;
+            ->toArray();
 
         $this->assertEquals('10% Off', $percent['formatted']);
     }
@@ -63,6 +63,15 @@ class PercentValueTest extends TestCase
         $percent = PercentValue::fromFraction(1, 0);
         $this->assertEquals('', $percent->formatted);
         $this->assertNull($percent->value);
+    }
+
+    public function testFromFractionWithZeroDenominator(): void
+    {
+        $percent = PercentValue::fromFraction(1, 0);
+        $this->assertInstanceOf(NullValue::class, $percent);
+
+        $percent = PercentValue::fromFraction(1, 0.0);
+        $this->assertInstanceOf(NullValue::class, $percent);
     }
 
     public function testFromWhole(): void
@@ -93,8 +102,7 @@ class PercentValueTest extends TestCase
         $percent = PercentValue::fromWhole(10)
             ->setPrecision(0)
             ->formatWith(fn(PercentValue $p) => "$p Off")
-            ->toArray()
-        ;
+            ->toArray();
 
         $this->assertEquals('10% Off', $percent['formatted']);
     }


### PR DESCRIPTION
Cast the given denominator to a float as the integer zero does not match the float zero (`0 !== 0.0`).