### PR TITLE
Percent Formatting When Printed

### DIFF
--- a/src/Values/PercentValue.php
+++ b/src/Values/PercentValue.php
@@ -21,6 +21,8 @@ class PercentValue extends FloatValue
 
     public function toString(): string
     {
-        return number_format($this->value * 100, $this->precision) . '%';
+        return $this->formatter
+            ? $this->formatted
+            : number_format($this->value * 100, $this->precision) . '%';
     }
 }

--- a/tests/Values/PercentValueTest.php
+++ b/tests/Values/PercentValueTest.php
@@ -106,4 +106,13 @@ class PercentValueTest extends TestCase
 
         $this->assertEquals('10% Off', $percent['formatted']);
     }
+
+    public function testUsesFormatterWhenPrinted(): void
+    {
+        $percent = PercentValue::fromWhole(10)
+            ->setPrecision(0)
+            ->formatWith(fn(PercentValue $p) => "$p Off");
+
+        $this->assertEquals('10% Off', (string) $percent);
+    }
 }


### PR DESCRIPTION
When a custom formatter is used on the `PercentValue` ensure that is used when printing the value to a string instead of the default formatting (ie: `10%`).